### PR TITLE
Update all tests to use Matlab's built in runtests

### DIFF
--- a/doc_src/MSATdevelop.txt
+++ b/doc_src/MSATdevelop.txt
@@ -16,5 +16,5 @@ Functions should be documented in a comment block at the start of each Matlab fi
 Testing
 -------
 
-MSAT is distributed with a large number of test cases. These are run using the link: http://www.mathworks.com/matlabcentral/fileexchange/22846-matlab-xunit-test-framework[xUnit test framework]. This must be installed and present in the Matlab path for the tests to be run. Once this is done the tests can be run from within Matlab by navigating to the tests subdirectory and executing the "runtests" command. Tests for new functions (and new tests for existing functions) should be added to this directory.
+MSAT is distributed with a large number of test cases. These are run using the Matlab `runtests()` built in function with tests being found in the `tests` directory. However, we make use of the xUnit test framework to access floating point aware assert statments. This must therefore be installed and present in the Matlab path for the tests to be run. Make sure a new(ish) version of the package is installed to avoid overloading the runtests built in. Tests for new functions (and new tests for existing functions) should be added to the tests directory.
 

--- a/tests/test_MS_TI.m
+++ b/tests/test_MS_TI.m
@@ -1,8 +1,4 @@
-function test_suite = test_MS_TI
-initTestSuite;
-end
-
-function test_MS_TI_crosscheck
+%% test_MS_TI_crosscheck
 
 % Check we get the same results from the two VTI routines. 
     
@@ -32,9 +28,7 @@ function test_MS_TI_crosscheck
    
    assertElementsAlmostEqual(C, Cl) ;
 
-end 
-
-function test_MS_TI_parameters_1
+%% test_MS_TI_parameters_1
 
 % Check we get the same results from the two VTI routines. 
     
@@ -63,9 +57,7 @@ function test_MS_TI_parameters_1
    C3 = MS_TI(vpa, vsa, rh_in, xi, phi, eta,'global') ;
    assertElementsAlmostEqual(C, C3);
 
-end
-
-function test_MS_TI_parameters_errors
+%% test_MS_TI_parameters_errors
 
     [C, rh] = MS_elasticDB('stishovite');
     
@@ -77,10 +69,8 @@ function test_MS_TI_parameters_errors
     
     f = @()MS_TI_parameters(MS_rot3(C, 0.0, 90.0, 0.0), rh);
         assertExceptionThrown(f, 'MS:BadTIelasticity');
-end
 
-
-function test_MS_TI_apatite
+%% test_MS_TI_apatite
 
     [C, rh] = MS_elasticDB('apatite');
     
@@ -95,9 +85,7 @@ function test_MS_TI_apatite
     assertElementsAlmostEqual(C, C2);
     assertElementsAlmostEqual(C, C3);
     
-end
-
-function test_MS_TI_apatite_units
+%% test_MS_TI_apatite_units
 
     [C, rh] = MS_elasticDB('apatite');
     
@@ -133,4 +121,3 @@ function test_MS_TI_apatite_units
     assertElementsAlmostEqual(eps, eps1);
     assertElementsAlmostEqual(gam, gam1);
     assertElementsAlmostEqual(del, del1);
-end

--- a/tests/test_MS_VRH.m
+++ b/tests/test_MS_VRH.m
@@ -1,8 +1,4 @@
-function test_suite = test_MS_VRH
-initTestSuite;
-end
-
-function test_MS_VRH_onephase
+%% test_MS_VRH_onephase
     % Test the Voigt-Reuss-Hill avarage does not
     % change the result for a single phase 
     % calculation
@@ -17,9 +13,8 @@ function test_MS_VRH_onephase
     assertElementsAlmostEqual(MS_VRH([50,50],C_in,10,C_in,10), C_in);
     assertElementsAlmostEqual(MS_VRH([9987,932],C_in,10,C_in,10), C_in);
     assertElementsAlmostEqual(MS_VRH([9987 932 5],C_in,10,C_in,10,C_in,10), C_in);
-end
 
-function test_MS_VRH_badinput
+%% test_MS_VRH_badinput
     C_in = [  49.67  13.18   13.18   000.0   000.0   000.0
               13.18  49.67   13.18   000.0   000.0   000.0
               13.18  13.18   49.67   000.0   000.0   000.0
@@ -28,9 +23,8 @@ function test_MS_VRH_badinput
               000.0  000.0   000.0   000.0   000.0   12.78];
     f = @()MS_VRH([0.333,0.333,0.333],C_in,10,C_in,10);
     assertExceptionThrown(f, 'MS:VRH:args');
-end
 
-function test_MS_VRH_onephase_vectors
+%% test_MS_VRH_onephase_vectors
     % Test the Voigt-Reuss-Hill avarage does not
     % change the result for a single phase 
     % calculation - vector form
@@ -52,9 +46,8 @@ function test_MS_VRH_onephase_vectors
     Cs(:,:,2) = C_in;
     Cs(:,:,3) = C_in;
     assertElementsAlmostEqual(MS_VRH([9987 932 5],Cs,[10 10 10]), C_in);
-end
 
-function test_MS_VRH_badinput_vectors
+%% test_MS_VRH_badinput_vectors
     C_in = [  49.67  13.18   13.18   000.0   000.0   000.0
               13.18  49.67   13.18   000.0   000.0   000.0
               13.18  13.18   49.67   000.0   000.0   000.0
@@ -75,4 +68,4 @@ function test_MS_VRH_badinput_vectors
     assertExceptionThrown(f, 'MS:VRH:args');
     f = @()MS_VRH([0.333,0.333,0.333],ones(5,6,3),[10 10 10]);
     assertExceptionThrown(f, 'MS:VRH:args');
-end
+

--- a/tests/test_MS_VTI.m
+++ b/tests/test_MS_VTI.m
@@ -1,23 +1,19 @@
-function test_suite = test_MS_VTI
-initTestSuite;
-end
+%% test_MS_VTI_crosscheck
 
-function test_MS_VTI_crosscheck
-
-%% Check we get the same results from the two VTI routines. 
+% Check we get the same results from the two VTI routines. 
     
-%% generate elasticities from thomsen parameters.
+% generate elasticities from thomsen parameters.
    rh = 4000 ; 
    vpv = 8 ;
    vsv = 5 ;
    
    C = MS_VTI(vpv,vsv,4000,0.05,0.05,0.00) ;
    
-%% calculate parameters for VTI2
+% calculate parameters for VTI2
    vph = sqrt(C(1,1)*1e9./rh)./1e3 ;
    vsh = sqrt(C(6,6)*1e9./rh)./1e3 ;
    
-%% average velocities
+% average velocities
    vpa = sqrt((vpv.^2+4.*vph.^2)./5) ;
    vsa = sqrt((2.*vsv.^2+vsh.^2)./3) ;
    
@@ -28,5 +24,3 @@ function test_MS_VTI_crosscheck
    Cl = MS_VTI2(vpa,vsa,rh,xi,phi,eta) ;
    
    assertElementsAlmostEqual(C, Cl) ;
-
-end 

--- a/tests/test_MS_Vrot3.m
+++ b/tests/test_MS_Vrot3.m
@@ -1,17 +1,12 @@
-function test_suite = test_MS_Vrot3
-initTestSuite;
-end
-
-function test_MS_Vrot3_simple
+%% test_MS_Vrot3_simple
 
   V = [1 0 0];
   assertElementsAlmostEqual(MS_Vrot3(V, 0.0, 0.0, 0.0), V); 
   assertElementsAlmostEqual(MS_Vrot3(V', 0.0, 0.0, 0.0), V');
   assertElementsAlmostEqual(MS_Vrot3(V, 0.0, 180.0, 0.0), [-1 0 0]); 
   assertElementsAlmostEqual(MS_Vrot3(V', 0.0, 180.0, 0.0), [-1 0 0]');
-end
 
-function test_MS_Vrot3_errors
+%% test_MS_Vrot3_errors
 
     V = [1 0 0];
     f = @()MS_Vrot3(V, 0.0, 0.0, 0.0, 'order', [1 2 4]);
@@ -24,4 +19,3 @@ function test_MS_Vrot3_errors
     f = @()MS_Vrot3([1 0 0 0], 0.0, 0.0, 0.0);
     assertExceptionThrown(f, 'MS:VROT3BadInputMatrix')
 
-end

--- a/tests/test_MS_anisotropy.m
+++ b/tests/test_MS_anisotropy.m
@@ -1,8 +1,4 @@
-function test_suite = test_MS_anisotropy
-initTestSuite;
-end
-
-function test_MS_anisotropy_isotropic
+%% test_MS_anisotropy_isotropic
 
   Ciso = [166.6667   66.6667   66.6667         0         0         0; ...
            66.6667  166.6667   66.6667         0         0         0; ...
@@ -17,5 +13,5 @@ function test_MS_anisotropy_isotropic
   assertElementsAlmostEqual(lma, 1.0);
   assertElementsAlmostEqual(zA, 1.0);
   assertElementsAlmostEqual(cbA, 0.0);
-end
+
 

--- a/tests/test_MS_axes.m
+++ b/tests/test_MS_axes.m
@@ -1,8 +1,4 @@
-function test_suite = test_MS_axes
-initTestSuite;
-end
-
-function test_MS_axes_reference
+%% test_MS_axes_reference
     % Test the olivine example from page 671 of B&C
     % This checks that (for this case) the orentation
     % is correct (no permutation of axes).
@@ -33,9 +29,9 @@ function test_MS_axes_reference
 
       assertElementsAlmostEqual(MS_axes(C1),C_ref);
     end
-end
 
-function test_MS_axes_ortho
+
+%% test_MS_axes_ortho
     % Test the interpolator works for constant
     % matrices rotated about axies
  
@@ -55,9 +51,9 @@ function test_MS_axes_ortho
       assertElementsAlmostEqual(MS_axes(C1),MS_axes(C2));
     
    end
-end
 
-function test_MS_axes_triclin_weak
+
+%% test_MS_axes_triclin_weak
    % Test the interpolator works for constant
    % matrices rotated about axes
    close all
@@ -83,11 +79,11 @@ function test_MS_axes_triclin_weak
       assertElementsAlmostEqual(MS_axes(C1),MS_axes(C2));
     
    end
-end
 
-function test_MS_axes_triclin_strong
-%% Test the interpolator works for constant
-%% matrices rotated about axes
+
+%% test_MS_axes_triclin_strong
+% Test the interpolator works for constant
+% matrices rotated about axes
  
    [C, r] = MS_elasticDB('albite');
 
@@ -106,9 +102,9 @@ function test_MS_axes_triclin_strong
       assertElementsAlmostEqual(MS_axes(C1),MS_axes(C2));
     
    end
-end
 
-function test_MS_axes_triclin_strong_rots
+
+%% test_MS_axes_triclin_strong_rots
     % Test the interpolator works for constant
     % matrices rotated about axes
  
@@ -131,9 +127,9 @@ function test_MS_axes_triclin_strong_rots
       assertElementsAlmostEqual(C1,C3);
     
    end
-end
 
-function test_MS_axes_errors
+
+%% test_MS_axes_errors
 
     [C, ~] = MS_elasticDB('olivine');
     f = @()MS_axes(C, 'NotAnArgument');
@@ -152,4 +148,4 @@ function test_MS_axes_errors
        val = 1;
     end
     assert(val==1, 'No error thrown')
-end
+

--- a/tests/test_MS_build_isotropic.m
+++ b/tests/test_MS_build_isotropic.m
@@ -1,8 +1,4 @@
-function test_suite = test_MS_build_isotropic
-initTestSuite;
-end
-
-function test_MS_build_isotropic_inputs
+%% test_MS_build_isotropic_inputs
 
     [C r] = MS_elasticDB('ol');
     [K_vrh, G_vrh] = MS_polyaverage(C);
@@ -30,10 +26,10 @@ function test_MS_build_isotropic_inputs
     assertElementsAlmostEqual(MS_build_isotropic('e', E,'K',K), C);
     assertElementsAlmostEqual(MS_build_isotropic('M', M,'mu',mu), C);
     assertElementsAlmostEqual(MS_build_isotropic('mu', mu,'M',M), C);
-end
 
 
-function test_MS_build_isotropic_errors
+
+%% test_MS_build_isotropic_errors
 
     [C r] = MS_elasticDB('ol');
     [K_vrh, G_vrh] = MS_polyaverage(C);
@@ -48,4 +44,3 @@ function test_MS_build_isotropic_errors
     f = @()MS_build_isotropic('lam', C(1,2),'bob',C(1,2));
     assertExceptionThrown(f, 'MS:buildiso:wrongargs');
     
-end

--- a/tests/test_MS_checkC.m
+++ b/tests/test_MS_checkC.m
@@ -1,17 +1,13 @@
-function test_suite = test_MS_checkC
-initTestSuite;
-end
-
-function test_MS_checkC_isNum
+%% test_MS_checkC_isNum
     f = @()MS_checkC('My matrix');
     assertExceptionThrown(f, 'MS:CHECKCNotNumeric');
     f = @()MS_checkC({23,22});
     assertExceptionThrown(f, 'MS:CHECKCNotNumeric');
     
-end
 
 
-function test_MS_checkC_size
+
+%% test_MS_checkC_size
     f = @()MS_checkC([1 1 1 1 1 1]);
     assertExceptionThrown(f, 'MS:CHECKCnot6x6');
     f = @()MS_checkC(ones(6,6,6));
@@ -20,27 +16,25 @@ function test_MS_checkC_size
     assertExceptionThrown(f, 'MS:CHECKCnot6x6');
     f = @()MS_checkC(ones(7,7));
     assertExceptionThrown(f, 'MS:CHECKCnot6x6');
-end
 
-function test_MS_checkC_psodef
+
+%% test_MS_checkC_psodef
 
     f = @()MS_checkC(-1.*ones(6,6));
     assertExceptionThrown(f, 'MS:CHECKCnotposdef');
 
-end
 
-function test_MS_checkC_zeros
+%% test_MS_checkC_zeros
 
     f = @()MS_checkC(zeros(6,6));
     assertExceptionThrown(f, 'MS:CHECKCbadzeros');
     
-end
 
-function test_MS_checkC_supression
+
+%% test_MS_checkC_supression
 
     assert(MS_checkC(zeros(6,6), 'nozerochk', 'nopdefchk') == 1)
     assert(MS_checkC(-1*ones(6,6), 'nopdefchk') == 1)
     assert(MS_checkC(zeros(6,6), 'fast') == 1)
     assert(MS_checkC(-1*ones(6,6), 'fast') == 1)
 
-end

--- a/tests/test_MS_cij2cijkl.m
+++ b/tests/test_MS_cij2cijkl.m
@@ -1,11 +1,6 @@
-function test_suite = test_MS_cij2cijkl
-initTestSuite;
-end
-
-function test_MS_cij2cijkl_simple
+%% test_MS_cij2cijkl_simple
 
     C = ones(6,6);
     CC = ones(3,3,3,3);
     assertElementsAlmostEqual(CC, MS_cij2cijkl(C));
     
-end

--- a/tests/test_MS_cijkl2cij.m
+++ b/tests/test_MS_cijkl2cij.m
@@ -1,11 +1,6 @@
-function test_suite = test_MS_cijkl2cij
-initTestSuite;
-end
-
-function test_MS_cijkl2cij_simple
+%% test_MS_cijkl2cij_simple
 
     C = ones(6,6);
     CC = ones(3,3,3,3);
     assertElementsAlmostEqual(C, MS_cijkl2cij(CC));
     
-end

--- a/tests/test_MS_decomp.m
+++ b/tests/test_MS_decomp.m
@@ -1,8 +1,4 @@
-function test_suite = test_MS_decomp
-initTestSuite;
-end
-
-function test_MS_decomp_olivine_lit
+%% test_MS_decomp_olivine_lit
     % Test the olivine example in the paper gives the published results
     
     % Published tensors... page 671
@@ -48,9 +44,9 @@ function test_MS_decomp_olivine_lit
     assertElementsAlmostEqual(C_ortc, C_ort, 'absolute', 0.1);
     assertElementsAlmostEqual(C_monc, C_mon, 'absolute', 0.1);
     assertElementsAlmostEqual(C_tric, C_tri, 'absolute', 0.1);
-end
 
-function test_MS_decomp_enst_lit
+
+%% test_MS_decomp_enst_lit
     % Test the olivine example in the paper gives the published results
     
     % Published tensors... page 671 - note types fixes in C_ort and C_hex
@@ -97,9 +93,9 @@ function test_MS_decomp_enst_lit
     assertElementsAlmostEqual(C_ortc, C_ort, 'absolute', 0.1);
     assertElementsAlmostEqual(C_monc, C_mon, 'absolute', 0.1);
     assertElementsAlmostEqual(C_tric, C_tri, 'absolute', 0.1);
-end
 
-function test_MS_decomp_DB
+
+%% test_MS_decomp_DB
     % Check that when we decompose things in the database, the sum of the 
     % elements add up to what we started with.
     
@@ -112,4 +108,3 @@ function test_MS_decomp_DB
         assertElementsAlmostEqual(C, Ctot);
     end
 
-end

--- a/tests/test_MS_effective_medium.m
+++ b/tests/test_MS_effective_medium.m
@@ -1,10 +1,4 @@
-function test_suite = test_MS_effective_medium
-initTestSuite;
-end
-
-
-
-function test_MS_effective_medium_TW
+%% test_MS_effective_medium_TW
 
    Ceff = [6.4667    3.5875    3.5875         0         0         0 ; ...
            3.5875    7.3026    3.7466         0         0         0 ; ...
@@ -32,9 +26,7 @@ function test_MS_effective_medium_TW
    assertElementsAlmostEqual(rheff, rheff1, 'absolute',0.001) ;
    assertElementsAlmostEqual(rheff, rheff2, 'absolute',0.001) ;
 
-end
-
-function test_MS_effective_medium_Hudson
+%% test_MS_effective_medium_Hudson
 
 %  water saturated cracks (HCS1) case from Crampin, 1984 (GJRAS, 76, pp 135-145)
 %  see table 1, page 139
@@ -87,9 +79,7 @@ function test_MS_effective_medium_Hudson
    assertElementsAlmostEqual(Ceff, Ceff2, 'absolute',0.01) ;
    assertElementsAlmostEqual(rheff, rheff2, 'absolute',0.01) ;
 
-end
-
-function test_MS_effective_medium_Backus
+%% test_MS_effective_medium_Backus
    
    [h,vp,vs,rh] = example_layering()  ;
    
@@ -121,8 +111,6 @@ function test_MS_effective_medium_Backus
    assertElementsAlmostEqual(Rho, rheff1, 'absolute',0.001) ;
    assertElementsAlmostEqual(Rho, rheff2, 'absolute',0.001) ;
    
-end
-
 function [h,vp,vs,rh] = example_layering()
 
    data = [ 5.0  2659.99    1319.64    2265.49 ; ...
@@ -153,4 +141,6 @@ function [h,vp,vs,rh] = example_layering()
    rh = data(:,4) ;
 
 end
+
+
 

--- a/tests/test_MS_effective_splitting_N.m
+++ b/tests/test_MS_effective_splitting_N.m
@@ -1,8 +1,4 @@
-function test_suite = test_MS_effective_splitting_N
-initTestSuite;
-end
-
-function test_MS_effective_splitting_N_graphs
+%% test_MS_effective_splitting_N_graphs
 
 % try to check we get the solutions suggested by fig 2 (a) and (b)
 
@@ -30,9 +26,7 @@ expec = [-20 0.8];
 res = [fe tle];
 assertElementsAlmostEqual(expec, res, 'relative', 0.1)
 
-end 
-
-function test_MS_effective_splitting_N_graphs_2
+%% test_MS_effective_splitting_N_graphs_2
 
 % try to check we get the solutions suggested by fig 2 (c) and (d)
 
@@ -60,9 +54,7 @@ expec = [-20 0.8];
 res = [fe tle];
 assertElementsAlmostEqual(expec, res, 'relative', 0.1)
 
-end 
-
-function test_MS_effective_splitting_N_aggregation
+%% test_MS_effective_splitting_N_aggregation
 
 % check that pre-aggregation of parameters works as expected.
 
@@ -90,9 +82,7 @@ expec = [0 1.0];
 res = [fe tle];
 assertElementsAlmostEqual(expec, res, 'relative', 0.1)
 
-end
-
-function test_MS_effective_splitting_N_errors
+%% test_MS_effective_splitting_N_errors
 
 f = @()MS_effective_splitting_N(1/20, 10, [90], [1.0, 1.0]);
 assertExceptionThrown(f, 'MS:ListsMustMatch')
@@ -106,12 +96,12 @@ assertExceptionThrown(f, 'MS:ListsMustMatch')
 f = @()MS_effective_splitting_N(1/20, 10, [90 80 70 60], [1 2 3]);
 assertExceptionThrown(f, 'MS:ListsMustMatch')
 
-end
+
 
 % try to check we get the solutions suggested by fig 2 (a), (c) and (d)
 % using the Gaussian Wavelet method. Seperate tests a bit because these 
 % are slow.
-function test_MS_effective_splitting_N_graphs_1_GW
+%% test_MS_effective_splitting_N_graphs_1_GW
 expec = [-40 1.0];
 [fe, tle] = MS_effective_splitting_N(1/20, 90, [90 140], [1.0, 1.0], ...
     'mode', 'gaussianwavelet');
@@ -129,9 +119,8 @@ assertElementsAlmostEqual(expec, res, 'relative', 0.1)
     'mode', 'gaussianwavelet');
 res = [fe tle];
 assertElementsAlmostEqual(expec, res, 'relative', 0.1);
-end
 
-function test_MS_effective_splitting_N_graphs_2_GW
+%% test_MS_effective_splitting_N_graphs_2_GW
 % Errors (differences) become bigger as period gets longer
 expec = [-25 0.8];
 [fe, tle] = MS_effective_splitting_N(1/5, 10, [90 140], [1.0, 1.0], ...
@@ -144,9 +133,8 @@ expec = [-20 0.8];
     'mode', 'gaussianwavelet');
 res = [fe tle];
 assertElementsAlmostEqual(expec, res, 'relative', 0.1);
-end 
 
-function test_MS_effective_splitting_N_graphs_3_GW
+%% test_MS_effective_splitting_N_graphs_3_GW
 
 % try to check we get the solutions suggested by fig 2 (c) and (d)
 
@@ -168,9 +156,8 @@ assertElementsAlmostEqual(expec, res, 'relative', 0.25)
      'mode', 'gaussianwavelet');
 res = [fe tle];
 assertElementsAlmostEqual(expec, res, 'relative', 0.25)
-end
- 
-function test_MS_effective_splitting_N_graphs_4_GW
+
+%% test_MS_effective_splitting_N_graphs_4_GW
 
 % Errors (differences) become bigger as period gets longer
 expec = [-25 0.8];
@@ -185,4 +172,4 @@ expec = [-20 0.8];
 res = [fe tle];
 assertElementsAlmostEqual(expec, res, 'relative', 0.1)
 
-end 
+ 

--- a/tests/test_MS_elasticDB.m
+++ b/tests/test_MS_elasticDB.m
@@ -1,8 +1,4 @@
-function test_suite = test_MS_elasticDB
-initTestSuite;
-end
-
-function test_MS_elasticDB_run
+%% test_MS_elasticDB_run
 
     infol = 'Single crystal olivine (Abramson et al, JGR, 1997; doi:10.1029/97JB00682)' ; 
     Cl = [320.5  68.1  71.6   0.0   0.0   0.0 ; ...
@@ -25,9 +21,7 @@ function test_MS_elasticDB_run
     assertElementsAlmostEqual(rh, rhl)
     assert(all(info == infol))
     
-end
-
-function test_MS_elasticDB_errors
+%% test_MS_elasticDB_errors
 
     f = @()MS_elasticDB('badname');
     assertExceptionThrown(f, 'MS:ELASTICDB:UNKNOWN')
@@ -45,5 +39,3 @@ function test_MS_elasticDB_errors
        val = 1;
     end
     assert(val==1, 'No error thrown')
-
-end

--- a/tests/test_MS_expand.m
+++ b/tests/test_MS_expand.m
@@ -1,8 +1,4 @@
-function test_suite = test_MS_expand
-   initTestSuite;
-end
-
-function test_MS_expand_isotropic
+%% test_MS_expand_isotropic
 
     C_in = [  0.0 0.0 0.0 0.0 0.0 0.0 ; ...
               0.0 0.0 0.0 0.0 0.0 0.0 ; ...
@@ -21,9 +17,7 @@ function test_MS_expand_isotropic
     assertElementsAlmostEqual(MS_expand(C_in, 'iso'), C_out);
     assertElementsAlmostEqual(MS_expand(C_in, 'auto'), C_out);
     
-end
-
-function test_MS_expand_cubic
+%% test_MS_expand_cubic
 
     C_in = [  0.0 66.6667 0.0 0.0 0.0 0.0 ; ...
               0.0 0.0 0.0 0.0 0.0 0.0 ; ...
@@ -42,9 +36,7 @@ function test_MS_expand_cubic
     assertElementsAlmostEqual(MS_expand(C_in, 'cubic'), C_out);
     assertElementsAlmostEqual(MS_expand(C_in, 'auto'), C_out);
     
-end
-
-function test_MS_expand_hexagonal
+%% test_MS_expand_hexagonal
 
     C_in = [ 153.6000         0   76.0444         0         0         0 ; ...
                     0         0         0         0         0         0 ; ...
@@ -64,9 +56,7 @@ function test_MS_expand_hexagonal
     assertElementsAlmostEqual(MS_expand(C_in, 'vti'), C_out);
     assertElementsAlmostEqual(MS_expand(C_in, 'auto'), C_out);
     
-end
-
-function test_MS_expand_orthorhombic
+%% test_MS_expand_orthorhombic
 
     C_in = [ 153.6000   76.8200   76.0444         0         0         0 ; ...
                     0  155.6000   76.1444         0         0         0 ; ...
@@ -86,9 +76,7 @@ function test_MS_expand_orthorhombic
     assertElementsAlmostEqual(MS_expand(C_in, 'orthorhombic'), C_out);
     assertElementsAlmostEqual(MS_expand(C_in, 'auto'), C_out);
     
-end
-
-function test_MS_expand_errors
+%% test_MS_expand_errors
 
 
 
@@ -138,6 +126,6 @@ function test_MS_expand_errors
               0.0 0.0 0.0 0.0 0.0 0.0 ];
     f = @()MS_expand(C_in, 'iso');
     assertExceptionThrown(f, 'MS:EXPANDbadiso')
-end
+
 
 

--- a/tests/test_MS_info.m
+++ b/tests/test_MS_info.m
@@ -1,8 +1,4 @@
-function test_suite = test_MS_info
-initTestSuite;
-end
-
-function test_MS_info_string
+%% test_MS_info_string
 
     [C, rh] = MS_elasticDB('ol');
     res = sprintf('\n---ROTATIONAL INFORMATION \n\n   Elasticity matrix appears unrotated.\n');  
@@ -17,9 +13,8 @@ function test_MS_info_string
         '          X3   8.343  4.791  4.368  9.240 \n']);
     S = MS_info(C, rh);
     assert(strcmp(res,S));
-end
 
-function test_MS_info_args
+%% test_MS_info_args
 
     [C, rh] = MS_elasticDB('ol');
     res = sprintf('\n---ROTATIONAL INFORMATION \n\n   Elasticity matrix appears unrotated.\n');  
@@ -43,9 +38,8 @@ function test_MS_info_args
         '          X3   8.343  4.791  4.368  9.240 \n']);
     S = MS_info(C, rh, 'mode', 'vel');
     assert(strcmp(res,S));
-end
 
-function test_MS_info_errors
+%% test_MS_info_errors
 
     [C, rh] = MS_elasticDB('ol');
     
@@ -63,4 +57,4 @@ function test_MS_info_errors
     
     f = @()MS_info(C, 'mode', 'vel');
     assertExceptionThrown(f, 'MS:INFO:NoVelocityInfo');
-end
+

--- a/tests/test_MS_interpolate.m
+++ b/tests/test_MS_interpolate.m
@@ -1,13 +1,5 @@
-function test_suite = test_MS_interpolate
-initTestSuite;
-end
 
-function [Cint] = mock_MS_interpolate(C1, C2, frac)
-    % Mockup of MS_interpolate that does not care about density.
-    [ Cint, ~ ] = MS_interpolate(C1, 1.0, C2, 1.0, frac);
-end
-
-function test_MS_interpolate_angs_ortho
+%% test_MS_interpolate_angs_ortho
     % Test the interpolator works for constant
     % matrices rotated about axies
  
@@ -34,9 +26,9 @@ function test_MS_interpolate_angs_ortho
     assertElementsAlmostEqual(mock_MS_interpolate(C110z, C10z, 0.5), C60z);
     assertElementsAlmostEqual(mock_MS_interpolate(C110z, C10z, 1.0), C110z);
     assertElementsAlmostEqual(mock_MS_interpolate(C110z, C10z, 0.0), C10z);
-end
 
-function test_MS_interpolate_angs_triclin
+
+%% test_MS_interpolate_angs_triclin
     % Test the interpolator works for constant
     % matrices rotated about axies
  
@@ -71,9 +63,9 @@ function test_MS_interpolate_angs_triclin
     assertElementsAlmostEqual(mock_MS_interpolate(C110z, C10z, 0.5), C60z);
     assertElementsAlmostEqual(mock_MS_interpolate(C110z, C10z, 1.0), C110z);
     assertElementsAlmostEqual(mock_MS_interpolate(C110z, C10z, 0.0), C10z);
-end
 
-function test_MS_interpolate_forst_fay
+
+%% test_MS_interpolate_forst_fay
     % Test the interpolator works for constant
     % matrices rotated about axies
  
@@ -92,4 +84,8 @@ function test_MS_interpolate_forst_fay
         assertElementsAlmostEqual(rho_common, r_int);
         
     end
+
+function [Cint] = mock_MS_interpolate(C1, C2, frac)
+    % Mockup of MS_interpolate that does not care about density.
+    [ Cint, ~ ] = MS_interpolate(C1, 1.0, C2, 1.0, frac);
 end

--- a/tests/test_MS_load.m
+++ b/tests/test_MS_load.m
@@ -1,8 +1,4 @@
-function test_suite = test_MS_load
-initTestSuite;
-end
-
-function test_MS_load_default
+%% test_MS_load_default
 
    [Cp,rp] = C_Ol() ;
    
@@ -28,9 +24,7 @@ function test_MS_load_default
    assertElementsAlmostEqual(Cp, Cl, 'absolute',0.001) ;
    assertElementsAlmostEqual(rp, rl, 'absolute',0.001) ;
 
-end
-
-function test_MS_load_Aij
+%% test_MS_load_Aij
 
    [Cp,rp] = C_Ol() ;
    
@@ -56,9 +50,7 @@ function test_MS_load_Aij
    assertElementsAlmostEqual(Cp, Cl, 'absolute',0.001) ;
    assertElementsAlmostEqual(rp, rl, 'absolute',0.001) ;
 
-end
-
-function test_MS_load_ematrix
+%% test_MS_load_ematrix
 
    [Cp,rp] = C_Ol() ;
    
@@ -81,9 +73,7 @@ function test_MS_load_ematrix
 
    assertElementsAlmostEqual(Cp, Cl, 'absolute',0.001) ;
 
-end
-
-function test_MS_load_iso
+%% test_MS_load_iso
 
    C33 = 237.5533 ;
    C66 = 79.5400 ;
@@ -104,9 +94,6 @@ function test_MS_load_iso
    assertElementsAlmostEqual(C33, Cl(3,3), 'absolute',0.001) ;
    assertElementsAlmostEqual(C66, Cl(6,6), 'absolute',0.001) ;
    assertElementsAlmostEqual(rho, rl, 'absolute',0.001) ;
-
-end
-
 
 function [C,r] = C_Ol()
 

--- a/tests/test_MS_norms.m
+++ b/tests/test_MS_norms.m
@@ -1,8 +1,4 @@
-function test_suite = test_MS_norms
-initTestSuite;
-end
-
-function test_MS_norms_olivine_lit
+%% test_MS_norms_olivine_lit
     % Test the olivine example in the paper gives the published results
     % Note that the decomposition is checked in test_MS_decomp
     
@@ -50,9 +46,8 @@ function test_MS_norms_olivine_lit
     assertElementsAlmostEqual((P(3)+P(4)), 0.055, 'absolute', 0.3);
     assertElementsAlmostEqual(P(5), 0.0, 'absolute', 0.3);
     assertElementsAlmostEqual(P(6), 0.0, 'absolute', 0.3);
-end
 
-function test_MS_norms_enst_lit
+%% test_MS_norms_enst_lit
     % Test the olivine example in the paper gives the published results
     
     % Published tensors... page 671 - note types fixes in C_ort and C_hex
@@ -100,5 +95,5 @@ function test_MS_norms_enst_lit
     assertElementsAlmostEqual((P(3)+P(4)), 0.049, 'absolute', 0.3);
     assertElementsAlmostEqual(P(5), 0.0, 'absolute', 0.3);
     assertElementsAlmostEqual(P(6), 0.0, 'absolute', 0.3);
-end
+
             

--- a/tests/test_MS_phasevels.m
+++ b/tests/test_MS_phasevels.m
@@ -1,8 +1,4 @@
-function test_suite = test_MS_phasevels
-initTestSuite;
-end
-
-function test_MS_phasevels_stishovite_graph
+%% test_MS_phasevels_stishovite_graph
 
     % Check we get the same results as those given in Mainprices review 
     % (Figure 3).
@@ -33,9 +29,7 @@ function test_MS_phasevels_stishovite_graph
     assert((vs1-8.4)^2<0.1^2, 'vs wrong'); % From graph
     assert((vs2-7.7)^2<0.1^2, 'vs wrong'); % From graph
 
-end 
-
-function test_MS_phasevels_stishovite_list
+%% test_MS_phasevels_stishovite_list
 
     [C, rh] = MS_elasticDB('stishovite');
     
@@ -48,9 +42,7 @@ function test_MS_phasevels_stishovite_list
     assertElementsAlmostEqual(vs1, [7.7, 7.7, 7.7]', 'absolute', 0.5); % From graph
     
 
-end
-
-function test_MS_phasevels_stishovite_errors
+%% test_MS_phasevels_stishovite_errors
 
     [C, rh] = MS_elasticDB('stishovite');
     
@@ -62,9 +54,7 @@ function test_MS_phasevels_stishovite_errors
     
     % How shoould we test MS:PHASEVELS:vectornotreal
     
-end
-
-function test_MS_phasevels_Cinvalid
+%% test_MS_phasevels_Cinvalid
 
     [C, rh] = MS_elasticDB('stishovite');
     C(3,6) = -675.0;
@@ -72,4 +62,3 @@ function test_MS_phasevels_Cinvalid
     f = @()MS_phasevels(C, rh, [90 90], [0 0]);
     assertExceptionThrown(f, 'MS:CHECKCnotsym');
     
-end

--- a/tests/test_MS_poisson.m
+++ b/tests/test_MS_poisson.m
@@ -1,8 +1,4 @@
-function test_suite = test_MS_poisson
-initTestSuite;
-end
-
-function test_MS_poisson_isotropic
+%% test_MS_poisson_isotropic
     
     Ciso = MS_build_isotropic('e', 300,'nu',0.2);
     % Do we always get the answer we expect for an isotropic case?
@@ -14,9 +10,8 @@ function test_MS_poisson_isotropic
     assertElementsAlmostEqual(MS_poisson( Ciso, [0 1 0], [1 0 0] ), 0.2);
     assertElementsAlmostEqual(MS_poisson( Ciso, [0 0 1], [0 1 0] ), 0.2);
     assertElementsAlmostEqual(MS_poisson( Ciso, [0 0 1], [1 0 0] ), 0.2);
-end 
 
-function test_MS_poisson_errors
+%% test_MS_poisson_errors
 
     Ciso = MS_build_isotropic('e', 300,'nu',0.2);
     % N not a unit vector
@@ -56,4 +51,3 @@ function test_MS_poisson_errors
     assertExceptionThrown(f, 'MS:CHECKUNITNotVec');
     f = @()MS_poisson( Ciso, [1 0 0 0], [0 0 1]);
     assertExceptionThrown(f, 'MS:CHECKUNITNotVec');
-end

--- a/tests/test_MS_polyaverage.m
+++ b/tests/test_MS_polyaverage.m
@@ -1,8 +1,4 @@
-function test_suite = test_MS_polyaverage
-initTestSuite;
-end
-
-function test_MS_polyaverage_stishovite
+%% test_MS_polyaverage_stishovite
 
 
    % Do we get the same numbers as WEIDNER et al. table 5?
@@ -14,6 +10,6 @@ function test_MS_polyaverage_stishovite
    assertElementsAlmostEqual([G_r], [208], 'absolute', 0.5);
    assertElementsAlmostEqual([K_v], [324], 'absolute', 0.5);
    assertElementsAlmostEqual([G_v], [232], 'absolute', 0.5);   
-end
+
 
 % No error cases to check!

--- a/tests/test_MS_rot3.m
+++ b/tests/test_MS_rot3.m
@@ -1,8 +1,4 @@
-function test_suite = test_MS_rot3
-initTestSuite;
-end
-
-function test_MS_rot_3_triclinic
+%% test_MS_rot_3_triclinic
 
     [C,r] = MS_elasticDB('alb') ;
     C1 = MS_rot3(C,30,45,60) ;
@@ -15,9 +11,7 @@ function test_MS_rot_3_triclinic
     assertElementsAlmostEqual(C, C2) ;
     assertElementsAlmostEqual(C1, C3) ;
 
-end
-
-function test_MS_rot_3_fuse
+%% test_MS_rot_3_fuse
 
     % Check out matrix method works like the explicit sum 
     % ususally given for tensor rotation.
@@ -56,9 +50,7 @@ function test_MS_rot_3_fuse
             
     end
     
-end
-
-function test_MS_rot_3_scalar_vector
+%% test_MS_rot_3_scalar_vector
 
     C_in = [  49.67  13.18   13.18   000.0   000.0   000.0
               13.18  49.67   13.18   000.0   000.0   000.0
@@ -83,9 +75,8 @@ function test_MS_rot_3_scalar_vector
     assertElementsAlmostEqual(Cs_in, MS_rot3(Cs_in, a, b, g))
     assertElementsAlmostEqual(Cs_in, MS_rot3(C_in, as, bs, gs))
     assertElementsAlmostEqual(Cs_in, MS_rot3(Cs_in, as, bs, gs))
-end
 
-function test_MS_rot_3_errors
+%% test_MS_rot_3_errors
 
     C_in = [  49.67  13.18   13.18   000.0   000.0   000.0
               13.18  49.67   13.18   000.0   000.0   000.0
@@ -116,9 +107,7 @@ function test_MS_rot_3_errors
     assertExceptionThrown(f, 'MS:ROT3:UnknownOption')
     
    
-end
-
-function test_MS_rot_3_vecerrors
+%% test_MS_rot_3_vecerrors
 
     C_in = [  49.67  13.18   13.18   000.0   000.0   000.0
               13.18  49.67   13.18   000.0   000.0   000.0
@@ -150,7 +139,7 @@ function test_MS_rot_3_vecerrors
     f = @()MS_rot3(Cs_in, as, bs, g);
     assertExceptionThrown(f, 'MS:ListsMustMatch')
     
-end
+
 
 
 % Direct way to rotate (Cij) by a rotation matrix

--- a/tests/test_MS_rotEuler.m
+++ b/tests/test_MS_rotEuler.m
@@ -1,8 +1,4 @@
-function test_suite = test_MS_rotEuler
-initTestSuite;
-end
-
-function test_MS_rot_Euler_scalar_vector
+%% test_MS_rot_Euler_scalar_vector
 
     C_in = [  49.67  13.18   13.18   000.0   000.0   000.0
               13.18  49.67   13.18   000.0   000.0   000.0
@@ -28,9 +24,7 @@ function test_MS_rot_Euler_scalar_vector
     assertElementsAlmostEqual(Cs_in, MS_rotEuler(C_in, phi1s, thetas, phi2s))
     assertElementsAlmostEqual(Cs_in, MS_rotEuler(Cs_in, phi1s, thetas, phi2s))
     
-end
-
-function test_MS_rot_Euler_scalar_vector_opts
+%% test_MS_rot_Euler_scalar_vector_opts
 
     % Note that for these rotations passive and active rotatiosn give the 
     % same result.
@@ -74,9 +68,7 @@ function test_MS_rot_Euler_scalar_vector_opts
     assertElementsAlmostEqual(Cs_in, MS_rotEuler(Cs_in, phi1s, thetas, phi2s, ...
         'sense', 'passive'))
     
-end
-
-function test_MS_rot_Euler_errors
+%% test_MS_rot_Euler_errors
 
     C_in = [  49.67  13.18   13.18   000.0   000.0   000.0
               13.18  49.67   13.18   000.0   000.0   000.0
@@ -114,9 +106,7 @@ function test_MS_rot_Euler_errors
     f = @()MS_rotEuler(Cs_in, phi1s, thetas, phi2, 'sense', 'bob');
     assertExceptionThrown(f, 'MS:ROTE:UnknownOption')
     
-end
-
-function test_MS_rot_Euler_VPSC
+%% test_MS_rot_Euler_VPSC
 
     % The VPSC code (version 6c) allows the calculation of texture (given
     % by sets of Euler angles) following deformation. It also calculates
@@ -191,5 +181,5 @@ function test_MS_rot_Euler_VPSC
     % Check result - only know VPSC result to 0.01 GPa
     assertElementsAlmostEqual(C_vpsc_voigt, C_voigt, 'absolute', 0.01)
 
-end
+
 

--- a/tests/test_MS_rotM.m
+++ b/tests/test_MS_rotM.m
@@ -1,8 +1,4 @@
-function test_suite = test_MS_rotM
-initTestSuite;
-end
-
-function test_MS_rotM_simple
+%% test_MS_rotM_simple
 
   I = [1 0 0 ; 0 1 0 ; 0 0 1];
   assertElementsAlmostEqual(MS_rotM(0.0, 0.0, 0.0), I); 
@@ -12,9 +8,8 @@ function test_MS_rotM_simple
   assertElementsAlmostEqual(MS_rotM(0.0, 0.0, 0.0, 'order', [3 1 2]), I);
   assertElementsAlmostEqual(MS_rotM(0.0, 0.0, 0.0, 'order', [2 3 1]), I);
   assertElementsAlmostEqual(MS_rotM(0.0, 0.0, 0.0, 'order', [2 1 3]), I);
-end
 
-function test_MS_rotM_errors
+%% test_MS_rotM_errors
 
     I = [1 0 0 ; 0 1 0 ; 0 0 1];
     f = @()MS_rotM(0.0, 0.0, 0.0, 'order', [1 2 4]);
@@ -24,4 +19,3 @@ function test_MS_rotM_errors
     f = @()MS_rotM(0.0, 0.0, 0.0, 'bob', [3 2 1]);
     assertExceptionThrown(f, 'MS:ROTM:UnknownOption')
 
-end

--- a/tests/test_MS_rotR.m
+++ b/tests/test_MS_rotR.m
@@ -1,8 +1,4 @@
-function test_suite = test_MS_rotR
-initTestSuite;
-end
-
-function test_MS_rotR_simple
+%% test_MS_rotR_simple
 
   C_ol = [320.5000   68.1000   71.6000         0         0         0; ...
            68.1000  196.5000   76.8000         0         0         0; ...
@@ -26,4 +22,3 @@ function test_MS_rotR_simple
                    0         0         0         0         0   77.0000];
   assertElementsAlmostEqual(C_ol_A, MS_rotR(C_ol, A));
          
-end

--- a/tests/test_MS_rotRandom.m
+++ b/tests/test_MS_rotRandom.m
@@ -1,8 +1,4 @@
-function test_suite = test_MS_rotRandom
-initTestSuite;
-end
-
-function test_MS_rotRandom_isotropic
+%% test_MS_rotRandom_isotropic
 
   % Check that a large number of randomly oriented crystals gives
   % an isotropic avarage. Can we think of better tests?
@@ -17,9 +13,7 @@ function test_MS_rotRandom_isotropic
                    ), ones(10000,1)));
   assert(uA<1E-4, 'Not isotropic')
   
-end
-
-function test_MS_rotRandom_euler
+%% test_MS_rotRandom_euler
 
   % Check that the output Euler angles give CC and vica versa.
   C = MS_elasticDB('ol');
@@ -34,4 +28,4 @@ function test_MS_rotRandom_euler
       assertElementsAlmostEqual(C, C_check)
   end
   
-end
+

--- a/tests/test_MS_splitting.m
+++ b/tests/test_MS_splitting.m
@@ -1,8 +1,4 @@
-function test_suite = test_MS_splitting
-   initTestSuite;
-end
-
-function test_MS_measure_no_splitting_dfreq
+%% test_MS_measure_no_splitting_dfreq
   
    % If we measure the splitting of an unsplit wave it should always
    % be 0 for tlag... this checks the dominant freq
@@ -20,9 +16,8 @@ function test_MS_measure_no_splitting_dfreq
    [~, tlag] = MS_measure_trace_splitting(time, T00, T90, 5.0, ...
       0.5, 4.0);
    assertElementsAlmostEqual([0.0 tlag], [0.0 0.0]) ;
-end
 
-function test_MS_measure_no_splitting_pol
+%% test_MS_measure_no_splitting_pol
   
    % If we measure the splitting of an unsplit wave it should always
    % be 0 for tlag... this checks the init_pol freq
@@ -45,9 +40,8 @@ function test_MS_measure_no_splitting_pol
    [~, tlag] = MS_measure_trace_splitting(time, T00, T90, 5.0, ...
       0.5, 4.0);
    assertElementsAlmostEqual([0.0 tlag], [0.0 0.0]) ;
-end
 
-function test_MS_measure_small_splitting_pol_1
+%% test_MS_measure_small_splitting_pol_1
   
    % We should recover the splitting we impose
    [time, T00, T90] = MS_make_trace(15.0, 0.2, 4.0);
@@ -56,9 +50,7 @@ function test_MS_measure_small_splitting_pol_1
       0.5, 4.0);
    assertElementsAlmostEqual([fast tlag], [25.0 0.2], 'absolute',0.0001) ;
    
-end
-
-function test_MS_measure_small_splitting_pol_2
+%% test_MS_measure_small_splitting_pol_2
   
    % We should recover the splitting we impose
    [time, T00, T90] = MS_make_trace(15.0, 0.2, 4.0);
@@ -67,9 +59,7 @@ function test_MS_measure_small_splitting_pol_2
       0.5, 4.0);
    assertElementsAlmostEqual([fast tlag], [25.0 0.02], 'absolute',0.1) ;
    
-end
-
-function test_MS_measure_small_splitting_pol_3
+%% test_MS_measure_small_splitting_pol_3
   
    % We should recover the splitting we impose
    [time, T00, T90] = MS_make_trace(15.0, 0.2, 4.0);
@@ -78,9 +68,7 @@ function test_MS_measure_small_splitting_pol_3
       0.5, 4.0);
    assertElementsAlmostEqual([fast tlag], [75.0 0.2], 'absolute',0.0001) ;
    
-end
-
-function test_MS_measure_small_splitting_pol_4
+%% test_MS_measure_small_splitting_pol_4
   
    % We should recover the splitting we impose
    [time, T00, T90] = MS_make_trace(15.0, 0.2, 4.0);
@@ -90,9 +78,7 @@ function test_MS_measure_small_splitting_pol_4
    % Errors go up close to null.
    assertElementsAlmostEqual([fast tlag], [16.0 0.1], 'absolute',0.1) ;
    
-end
-
-function test_MS_remove_splitting
+%% test_MS_remove_splitting
 
    % If we apply and remove splitting from a trace we should
    % get back what we started
@@ -130,4 +116,3 @@ function test_MS_remove_splitting
    [T00r T90r] = MS_split_trace(time, T00, T90, 82.0, 0.2);
    [T00r T90r] = MS_split_trace(time, T00r, T90r, 82.0, -0.2);
    assertElementsAlmostEqual([T00 T90], [T00r, T90r]);
-end

--- a/tests/test_MS_splitting_misfit.m
+++ b/tests/test_MS_splitting_misfit.m
@@ -1,8 +1,4 @@
-function test_suite = test_MS_splitting_misfit
-   initTestSuite;
-end
-
-function test_MS_splitting_misfit_Zero_cases
+%% test_MS_splitting_misfit_Zero_cases
    % check misfit between two identical splitting operators is zero for different
    % polarisations, frequencies and operators. 
 
@@ -16,9 +12,7 @@ function test_MS_splitting_misfit_Zero_cases
       assertElementsAlmostEqual(misfit, 0, 'absolute',0.001) ;
    end
 
-end 
-
-function test_MS_splitting_misfit_lam2S
+%% test_MS_splitting_misfit_lam2S
    % Check that the symmetrical mode works properly. 
    
    fast1 = 30  ;
@@ -32,9 +26,7 @@ function test_MS_splitting_misfit_lam2S
 
    assertElementsAlmostEqual(misfit1, misfit2, 'absolute',0.001) ;
 
-end 
-
-function test_MS_splitting_misfit_intensity
+%% test_MS_splitting_misfit_intensity
    % Check that the intensity mode works properly. This has a 
    % different periodicity to the other misfit measures.
    
@@ -48,9 +40,7 @@ function test_MS_splitting_misfit_intensity
 
    assertElementsAlmostEqual(misfit,0,'absolute',0.001) ;
 
-end 
-
-function test_MS_splitting_misfit_simple
+%% test_MS_splitting_misfit_simple
    % Check that the simple mode works properly. 
    
    fast1 = 90  ;
@@ -63,9 +53,7 @@ function test_MS_splitting_misfit_simple
 
    assertElementsAlmostEqual(misfit,0,'absolute',0.001) ;
 
-end 
-
-function test_MS_splitting_misfit_Worst_case
+%% test_MS_splitting_misfit_Worst_case
    % check misfit between two identical splitting operators is unity for
    % opposite parameters
 
@@ -76,9 +64,8 @@ function test_MS_splitting_misfit_Worst_case
    
    misfit = MS_splitting_misfit(fast1,tlag1,fast2,tlag2,spol,freq) ;
    assertElementsAlmostEqual(misfit, 1, 'absolute',0.001) ;
-end 
 
-function test_MS_splitting_misfit_analytical
+%% test_MS_splitting_misfit_analytical
    % Check that the misfit for a given parameter pair and a null result is
    % the same as the 2nd eigenvalue from an analytically constructed split
    % wave. 
@@ -100,7 +87,7 @@ function test_MS_splitting_misfit_analytical
    misfit = MS_splitting_misfit(fast,10,90,0.0,75,0.2) ;
    assertElementsAlmostEqual(misfit, lam2, 'absolute',0.001) ;
 
-end 
+ 
 
 function [amp] = FDGaussian(dt,T,padf)
 %function [A,t] = GaussWin(dt, T)

--- a/tests/test_MS_unwind_pm_90.m
+++ b/tests/test_MS_unwind_pm_90.m
@@ -1,8 +1,4 @@
-function test_suite = test_MS_unwind_pm_90
-initTestSuite;
-end
-
-function test_MS_unwind_0_900_scalar
+%% test_MS_unwind_0_900_scalar
     assertElementsAlmostEqual(MS_unwind_pm_90(30), 30);
     assertElementsAlmostEqual(MS_unwind_pm_90(361), 1);
     assertElementsAlmostEqual(MS_unwind_pm_90(-1), -1);
@@ -10,17 +6,14 @@ function test_MS_unwind_0_900_scalar
     assertElementsAlmostEqual(MS_unwind_pm_90(360), 0);
     assertElementsAlmostEqual(MS_unwind_pm_90(180), 0);
     assertElementsAlmostEqual(MS_unwind_pm_90(-180), 0);
-end
 
-function test_MS_unwind_0_90_vector
+%% test_MS_unwind_0_90_vector
     assertElementsAlmostEqual(MS_unwind_pm_90([30, 40]), [30, 40]);
     assertElementsAlmostEqual(MS_unwind_pm_90([0, 361]), [0, 1]);
     assertElementsAlmostEqual(MS_unwind_pm_90([1, -1]), [1, -1]);
     assertElementsAlmostEqual(MS_unwind_pm_90([0,0,0]), [0,0,0]);
     assertElementsAlmostEqual(MS_unwind_pm_90([360]), [0]);
-end
 
-function test_MS_unwind_0_90_error
+%% test_MS_unwind_0_90_error
     f = @()MS_unwind_pm_90('bob');
     assertExceptionThrown(f, 'MS:unwind_pm_90:BadInput');
-end


### PR DESCRIPTION
This makes tests easer to write, however, we still need xUnit to get access to things like assertAllClose for floating point tests.